### PR TITLE
Casting and mem leaks bugs

### DIFF
--- a/include/strman.h
+++ b/include/strman.h
@@ -16,7 +16,6 @@ char* generateSeparatorPattern(char priSep, char secSep, int len);
 void normalizeWithSeparator(char* str, char priSep, char secSep, int sepPatternLen);
 void equall(char** ptr, const char* text);
 void concat(char** ptr, const char* text);
-char* ccat(char* s1, const char* s2);
 char* intToString(int num, char* str);
 char* floatToString(float num, char* str);
 char* longIntToString(long int num, char* str);

--- a/src/strman.c
+++ b/src/strman.c
@@ -145,26 +145,6 @@ void concat(char** ptr, const char* text) {
     }
 }
 
-char* ccat(char* s1, const char* s2) {
-    if (!s2) return s1; // Nothing to append
-
-    size_t len1 = s1 ? strlen(s1) : 0;
-    size_t len2 = strlen(s2);
-
-    char* new_s1 = realloc(s1, len1 + len2 + 1); // +1 for null terminator
-    if (!new_s1) {
-        fprintf(stderr, "Memory allocation failed\n");
-        free(s1); // optional: free original if realloc fails
-        return NULL;
-    }
-
-    // Copy or append
-    if (!s1) new_s1[0] = '\0'; // if s1 was NULL, initialize
-
-    strcat(new_s1, s2); // safe because we allocated enough space
-    return new_s1;       
-}
-
 char* intToString(int num, char* str) {
     asprintf(&str, "%d", num); // ONLY in GNU the asprintf()
     return str;
@@ -193,9 +173,9 @@ char* charToString(const char c) {
     return str;
 }
 
-/* int stringToInt(char* str) {
-
-} */
+int stringToInt(char* str) {
+    int num = atoi(str);
+}
 
 // If i want make that when str is number return number else 0 i suppose
 /* int isStringInt(const char *str) {


### PR DESCRIPTION
There is auto casting between int, float and long int.
There is normal casting for bool.
String is a little more complicated.

string s = "hello";
(int or float or long int or bool) var = (int) | (float) | (long int) | (bool) s;

The var will be 1 (for bool it will be still 1 and it will be considered as true.
If the s was "" then the var would be 0.

But if you assign a different type to string, the result will be what you assign as string

string s1 = 100;  // s1 = "100"
string s2 = 5.5;  // s2 = "5.5"
string s3 = 30000000;  // s3 = "30000000"
string s4 = true;  // s4 = "true"

Also i fixed some memory leak's bugs.